### PR TITLE
Command console to migrate from Martin.Forms plugin

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -26,6 +26,11 @@ class Plugin extends PluginBase
         ];
     }
 
+    public function register()
+    {
+        $this->registerConsoleCommand('import.martinforms', \Publipresse\Forms\Console\ImportMartinForms::class);
+    }
+
     public function registerNavigation() {
 
         // Add menu item for all records
@@ -49,7 +54,7 @@ class Plugin extends PluginBase
                 ]
             ]
         ];
-        
+
         // Add menu item for each groups
         $groups = Record::all()->pluck('group')->unique();
         foreach($groups as $group) {
@@ -115,5 +120,5 @@ class Plugin extends PluginBase
             MagicForm::gdprClean();
         })->daily();
     }
-    
+
 }

--- a/console/ImportMartinForms.php
+++ b/console/ImportMartinForms.php
@@ -30,7 +30,7 @@ class ImportMartinForms extends Command
 
             $newRecord = new Record();
             $newRecord->group = $record->group;
-            $newRecord->form_data = $record->form_data;
+            $newRecord->form_data = json_decode($record->form_data, true);
             $newRecord->ip = $record->ip;
             $newRecord->unread = $record->unread;
             $newRecord->created_at = $record->created_at;

--- a/console/ImportMartinForms.php
+++ b/console/ImportMartinForms.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Publipresse\Forms\Console;
+
+use Db;
+use Illuminate\Console\Command;
+use Publipresse\Forms\Models\Record;
+
+class ImportMartinForms extends Command
+{
+    protected $name = 'import:martinforms';
+
+    protected $description = 'Import records from Martin.Forms plugin to Publipresse.Forms';
+
+    public function handle()
+    {
+        $records = Db::table('martin_forms_records')->get();
+        $count = $records->count();
+
+        if ($count === 0) {
+            $this->info('Nothing to migrate');
+            return;
+        }
+
+        foreach ($records as $record) {
+            if (!empty($record->deleted_at)) {
+                $count--;
+                continue;
+            }
+
+            $newRecord = new Record();
+            $newRecord->group = $record->group;
+            $newRecord->form_data = $record->form_data;
+            $newRecord->ip = $record->ip;
+            $newRecord->unread = $record->unread;
+            $newRecord->created_at = $record->created_at;
+            $newRecord->updated_at = $record->updated_at;
+
+            try {
+                $newRecord->save();
+            } catch (\Throwable $th) {
+                $count--;
+                continue;
+            }
+        }
+
+        $this->info($count . ' records migrated');
+    }
+}

--- a/console/ImportMartinForms.php
+++ b/console/ImportMartinForms.php
@@ -14,6 +14,10 @@ class ImportMartinForms extends Command
 
     public function handle()
     {
+        if (!$this->confirm('Are you sure you want to migrate records from Martin.Forms to Publipresse.Forms?')) {
+            return;
+        }
+
         $records = Db::table('martin_forms_records')->get();
         $count = $records->count();
 


### PR DESCRIPTION
Hi guys,

In one of our client's projects we needed to migrate records from Martin.Forms plugin to your plugin. We did that using console command and I think that it may be useful for others.

Have a good day,

Tomasz